### PR TITLE
Sort MissionFeatures by new and editing flags

### DIFF
--- a/GeoCollectTestTest/src/it/geosolutions/geocollect/android/core/test/MissionFeatureSortTest.java
+++ b/GeoCollectTestTest/src/it/geosolutions/geocollect/android/core/test/MissionFeatureSortTest.java
@@ -1,0 +1,93 @@
+package it.geosolutions.geocollect.android.core.test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+
+import it.geosolutions.geocollect.android.core.mission.MissionFeature;
+import it.geosolutions.geocollect.android.core.mission.utils.MissionFeatureSorter;
+import it.geosolutions.geocollect.model.config.MissionTemplate;
+import android.test.InstrumentationTestCase;
+
+public class MissionFeatureSortTest extends InstrumentationTestCase {
+
+	/**
+	 * tests the sorting of MissionFeatures by their editing and new flags
+	 */
+	public void testEditSort(){
+		
+		final String orderingField = "CODICE";
+		final boolean byDistance = false;
+		final boolean preferEdited = true;
+		
+		//1. test prefer edited
+		
+		final MissionFeatureSorter editSorter = new MissionFeatureSorter(orderingField, preferEdited, byDistance, false);
+		final ArrayList<MissionFeature> features = new ArrayList<MissionFeature>();
+		
+		features.add(createMissionFeature(false, false, orderingField, "abc"));
+		features.add(createMissionFeature(false, false, orderingField, "aabc"));
+		features.add(createMissionFeature(true,  false, orderingField, "new"));
+		features.add(createMissionFeature(false, false, orderingField, "def"));
+		features.add(createMissionFeature(false, false, orderingField, "xyz"));
+		features.add(createMissionFeature(false,  true, orderingField, "edit"));
+		features.add(createMissionFeature(true,   true, orderingField, "both"));
+		
+		Collections.sort(features, editSorter);
+		
+		//assert "both", "new" and "editing" are up, afterwards the other items in alphabetical order 
+		assertTrue(features.get(0).properties.get(orderingField).equals("both"));
+		assertTrue(features.get(1).properties.get(orderingField).equals("new"));
+		assertTrue(features.get(2).properties.get(orderingField).equals("edit"));
+		assertTrue(features.get(3).properties.get(orderingField).equals("aabc"));
+		assertTrue(features.get(4).properties.get(orderingField).equals("abc"));
+		assertTrue(features.get(5).properties.get(orderingField).equals("def"));
+		assertTrue(features.get(6).properties.get(orderingField).equals("xyz"));
+		
+		//2. test reversed
+		
+		final MissionFeatureSorter reversedSorter = new MissionFeatureSorter(orderingField, preferEdited, byDistance, true);
+		Collections.sort(features, reversedSorter);
+		//this is how reversion is actually done in SQLiteCascadeFeatureLoader
+		Collections.reverse(features);
+		
+		//assert "both", "new" and "editing" are still up, only all others afterwards are reversed
+		assertTrue(features.get(0).properties.get(orderingField).equals("both"));
+		assertTrue(features.get(1).properties.get(orderingField).equals("new"));
+		assertTrue(features.get(2).properties.get(orderingField).equals("edit"));
+		assertTrue(features.get(3).properties.get(orderingField).equals("xyz"));
+		assertTrue(features.get(4).properties.get(orderingField).equals("def"));
+		assertTrue(features.get(5).properties.get(orderingField).equals("abc"));
+		assertTrue(features.get(6).properties.get(orderingField).equals("aabc"));
+		
+		//3. do not prefer edited 
+		
+		final MissionFeatureSorter doNotPreferSorter = new MissionFeatureSorter(orderingField, false, byDistance, false);
+		Collections.sort(features, doNotPreferSorter);
+		
+		//assert alphabetical order
+		assertTrue(features.get(0).properties.get(orderingField).equals("aabc"));
+		assertTrue(features.get(1).properties.get(orderingField).equals("abc"));
+		assertTrue(features.get(2).properties.get(orderingField).equals("both"));
+		assertTrue(features.get(3).properties.get(orderingField).equals("def"));
+		assertTrue(features.get(4).properties.get(orderingField).equals("edit"));
+		assertTrue(features.get(5).properties.get(orderingField).equals("new"));
+		assertTrue(features.get(6).properties.get(orderingField).equals("xyz"));
+		
+	}
+	
+	private MissionFeature createMissionFeature(final boolean newFlag, final boolean editing, final String orderingField, final String name){
+		
+		MissionFeature mf = new MissionFeature();
+		mf.properties = new HashMap<String, Object>();
+		if(newFlag){			
+			mf.typeName = "typeName" + MissionTemplate.NEW_NOTICE_SUFFIX;
+		}else{
+			mf.typeName = "typeName";
+		}
+		mf.properties.put(orderingField, name);
+		mf.editing = editing;
+		
+		return mf;
+	}
+}

--- a/geocollect/android/app/res/values-it/strings.xml
+++ b/geocollect/android/app/res/values-it/strings.xml
@@ -116,6 +116,7 @@
     
     <string name="ordering_az">A-Z</string>
     <string name="ordering_distance">Distanza</string>
+    <string name="prefer_edited">Mostra in attesa</string>
     
     <string name="version">Versione</string>
     

--- a/geocollect/android/app/res/values/resources.xml
+++ b/geocollect/android/app/res/values/resources.xml
@@ -10,6 +10,7 @@
     <item type="id" name="overflow_order" />
     <item type="id" name="overflow_order_az" />
     <item type="id" name="overflow_order_distance" />
+    <item type="id" name="overflow_prefer_edited" />
     <item type="id" name="overflow_refresh" />
     
 </resources>

--- a/geocollect/android/app/res/values/strings.xml
+++ b/geocollect/android/app/res/values/strings.xml
@@ -116,6 +116,7 @@
     <string name="button_confirm_logout">Do you really want to logout?</string>
     <string name="ordering_az">A-Z</string>
     <string name="ordering_distance">Distance</string>
+    <string name="prefer_edited">Show pending uploads</string>
     <string name="version">Version</string>
     <string name="label_new">New</string>
     <string name="item_delete_title">Delete</string>

--- a/geocollect/android/app/src/it/geosolutions/geocollect/android/core/mission/PendingMissionListFragment.java
+++ b/geocollect/android/app/src/it/geosolutions/geocollect/android/core/mission/PendingMissionListFragment.java
@@ -43,6 +43,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.SharedPreferences.Editor;
 import android.content.res.Resources;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
@@ -587,6 +588,12 @@ public class PendingMissionListFragment extends SherlockListFragment implements 
 
         // Creating the Overflow Menu
         SubMenu subMenu1 = menu.addSubMenu(0, R.id.overflow_menu, 90, "Overflow Menu");
+        
+        //add sort by edit item
+        MenuItem editItem = subMenu1.add(0, R.id.overflow_prefer_edited, Menu.NONE, R.string.prefer_edited);
+        editItem.setCheckable(true);
+        editItem.setChecked(sp.getBoolean(SQLiteCascadeFeatureLoader.PREFER_EDITED, false));
+        
         SubMenu subMenu2 = subMenu1.addSubMenu(0, R.id.overflow_order, Menu.NONE, R.string.order_by_ellipsis);
         subMenu2.setGroupCheckable(1, true, true);
 
@@ -669,6 +676,19 @@ public class PendingMissionListFragment extends SherlockListFragment implements 
             item.setChecked(true);
             return true;
 
+        } else if (id == R.id.overflow_prefer_edited) {
+        	
+        	 //toggle current state
+        	 SharedPreferences sp = getActivity().getSharedPreferences(SQLiteCascadeFeatureLoader.PREF_NAME, Context.MODE_PRIVATE);
+        	 final boolean current = sp.getBoolean(SQLiteCascadeFeatureLoader.PREFER_EDITED, false);
+        	 Editor ed = sp.edit();
+        	 ed.putBoolean(SQLiteCascadeFeatureLoader.PREFER_EDITED, !current);
+        	 ed.apply();
+        	 //update menu item state
+        	 item.setChecked(!current);
+        	 // reload with this state
+        	 forceLoad();
+        	
         } else if (id == R.id.filter) {
 
             // Clear the Spatial Filter

--- a/geocollect/android/app/src/it/geosolutions/geocollect/android/core/mission/utils/MissionFeatureSorter.java
+++ b/geocollect/android/app/src/it/geosolutions/geocollect/android/core/mission/utils/MissionFeatureSorter.java
@@ -1,0 +1,127 @@
+/*
+ * GeoSolutions map - Digital field mapping on Android based devices
+ * Copyright (C) 2013 - 2017  GeoSolutions (www.geo-solutions.it)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package it.geosolutions.geocollect.android.core.mission.utils;
+
+import it.geosolutions.geocollect.android.core.mission.MissionFeature;
+import it.geosolutions.geocollect.model.config.MissionTemplate;
+
+import java.util.Comparator;
+
+import android.util.Log;
+
+/**
+ * class to compare MissionFeatures by their "new" @link MissionTemplate.NEW_NOTICE_SUFFIX
+ *  and "editing" flags
+ * 
+ * @author Robert Oehler
+ *
+ */
+
+
+public class MissionFeatureSorter implements Comparator<MissionFeature>{
+	
+	private String orderingField;
+	private boolean byDistance;
+	private boolean reverse;
+	private boolean preferEdited;
+	
+	public MissionFeatureSorter(final String pOrderingField, boolean pPreferEdited, boolean pByDistance, boolean pReverse){
+		
+		this.orderingField = pOrderingField;
+		this.byDistance    = pByDistance;
+		this.reverse       = pReverse;
+		this.preferEdited  = pPreferEdited;
+	}
+
+	@Override
+	public int compare(MissionFeature lhs, MissionFeature rhs) {
+		
+		if(preferEdited){
+			
+			//check the new flag	
+			boolean bothNew = lhs.typeName != null && lhs.typeName.endsWith(MissionTemplate.NEW_NOTICE_SUFFIX) &&
+							  rhs.typeName != null && rhs.typeName.endsWith(MissionTemplate.NEW_NOTICE_SUFFIX);
+			
+			//if both have the new flag we cannot compare by this flag continue with next criterion
+			if(!bothNew){
+				//otherwise check
+				 if(lhs.typeName != null && lhs.typeName.endsWith(MissionTemplate.NEW_NOTICE_SUFFIX)){
+					 return reverse ? 1 : -1;
+				 }else if(rhs.typeName != null && rhs.typeName.endsWith(MissionTemplate.NEW_NOTICE_SUFFIX)){
+					 return reverse ? -1 : 1;
+				 }
+			}
+			//not new, editing ?
+			//when both are editing we cannot use this criterion
+			if(!(lhs.editing && rhs.editing)){	 
+				//otherwise check which
+				 if(lhs.editing){
+					 return reverse ? 1 : -1;
+				 }else if(rhs.editing){
+					 return reverse ? -1 : 1;
+				 }
+			}
+		}
+		
+		//could not decide by new or editing - use either distance or alphabetical
+
+		if (byDistance) {
+			// sort by distance
+			if (lhs.properties == null
+					|| !lhs.properties.containsKey(MissionFeature.DISTANCE_VALUE_ALIAS)
+					|| lhs.properties.get(MissionFeature.DISTANCE_VALUE_ALIAS) == null) {
+				return 1;
+			}
+			if (rhs.properties == null
+					|| !rhs.properties
+							.containsKey(MissionFeature.DISTANCE_VALUE_ALIAS)
+					|| rhs.properties.get(MissionFeature.DISTANCE_VALUE_ALIAS) == null) {
+				return -1;
+			}
+
+			try {
+				long ldistance = Math.round(Double.parseDouble(lhs.properties.get(MissionFeature.DISTANCE_VALUE_ALIAS).toString()));
+				long rdistance = Math.round(Double.parseDouble(rhs.properties.get(MissionFeature.DISTANCE_VALUE_ALIAS).toString()));
+				return (int) (rdistance - ldistance);
+			} catch (NumberFormatException nfe) {
+				return 0;
+			}
+
+		} else {
+			// sort alphabetical
+
+			if (lhs.properties == null || !lhs.properties.containsKey(orderingField)) {
+				return 1;
+			}
+			if (rhs.properties == null || !rhs.properties.containsKey(orderingField)) {
+				return -1;
+			}
+
+			try {
+				return lhs.properties
+						.get(orderingField)
+						.toString()
+						.compareTo(rhs.properties.get(orderingField).toString());
+			} catch (NullPointerException npe) {
+				return 0;
+			}
+
+		}
+	}
+
+}

--- a/geocollect/android/app/src/it/geosolutions/geocollect/android/core/mission/utils/SQLiteCascadeFeatureLoader.java
+++ b/geocollect/android/app/src/it/geosolutions/geocollect/android/core/mission/utils/SQLiteCascadeFeatureLoader.java
@@ -58,6 +58,7 @@ public class SQLiteCascadeFeatureLoader extends AsyncTaskLoader<List<MissionFeat
 	public static String LAST_UPDATE_PREF = "LastUpdate";
 	public static String REVERSE_ORDER_PREF = "ReverseOrdering";
 	public static String ORDER_BY_DISTANCE = "OrderByDistance";
+	public static String PREFER_EDITED = "PreferEdited";
 	
 	/**
 	 * Preferences Strings for the Spatial Filter
@@ -469,54 +470,12 @@ public class SQLiteCascadeFeatureLoader extends AsyncTaskLoader<List<MissionFeat
 
         mData.addAll(missions);
         if(orderingField != null && !orderingField.isEmpty()){
+        	
             boolean reverse = mPrefs.getBoolean(REVERSE_ORDER_PREF, false);
             boolean useDistance = mPrefs.getBoolean(ORDER_BY_DISTANCE, false);
-            
-            if(useDistance){
-                Collections.sort(mData, new Comparator<MissionFeature>() {
-        
-                    @Override
-                    public int compare(MissionFeature lhs, MissionFeature rhs) {
-                        if(lhs.properties == null
-                                || !lhs.properties.containsKey(MissionFeature.DISTANCE_VALUE_ALIAS)
-                                || lhs.properties.get(MissionFeature.DISTANCE_VALUE_ALIAS)== null){
-                            return 1;
-                        }
-                        if(rhs.properties == null
-                                || !rhs.properties.containsKey(MissionFeature.DISTANCE_VALUE_ALIAS)
-                                || rhs.properties.get(MissionFeature.DISTANCE_VALUE_ALIAS)== null){
-                            return -1;
-                        }
-                        
-                        try{
-                            long ldistance = Math.round(Double.parseDouble(lhs.properties.get(MissionFeature.DISTANCE_VALUE_ALIAS).toString()));
-                            long rdistance = Math.round(Double.parseDouble(rhs.properties.get(MissionFeature.DISTANCE_VALUE_ALIAS).toString()));
-                            return (int) (rdistance-ldistance);
-                        }catch (NumberFormatException nfe){
-                            return 0;
-                        }
-                    }
-                } );
-            }else{
-                Collections.sort(mData, new Comparator<MissionFeature>() {
-                    
-                    @Override
-                    public int compare(MissionFeature lhs, MissionFeature rhs) {
-                        if(lhs.properties == null || !lhs.properties.containsKey(orderingField)){
-                            return 1;
-                        }
-                        if(rhs.properties == null || !rhs.properties.containsKey(orderingField)){
-                            return -1;
-                        }
-                        
-                        try{
-                            return lhs.properties.get(orderingField).toString().compareTo(rhs.properties.get(orderingField).toString());
-                        }catch (NullPointerException npe){
-                            return 0;
-                        }
-                    }
-                } );
-            }
+            boolean preferEdited = mPrefs.getBoolean(PREFER_EDITED, false);
+            	
+            Collections.sort(mData, new MissionFeatureSorter(orderingField, preferEdited, useDistance, reverse));
             
             if(reverse){
                 Collections.reverse(mData);


### PR DESCRIPTION
Implementation for task "Highlights new and edited items".

Instead of adding a another sorter to the already existing for "byDistance" and "alphabetical" I made one sorter which handles all available sorting options.